### PR TITLE
Fix Vite build configuration: Change manifest option from true to 'ma…

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -18,7 +18,7 @@ export default defineConfig({
         },
     },
     build: {
-        manifest: true,
+        manifest: 'manifest.json',
         outDir: 'public/build',
         rollupOptions: {
             input: {


### PR DESCRIPTION
This pull request updates the Vite build configuration to specify the manifest file name directly. This change ensures that the build process outputs the manifest as `manifest.json` instead of using the default boolean setting.

* Configuration update: Changed the `manifest` property in the `build` section of `vite.config.js` to `'manifest.json'` for explicit manifest file naming.…nifest.json'