### PR TITLE
Fix Google authentication redirect URLs in services and login view

### DIFF
--- a/config/services.php
+++ b/config/services.php
@@ -38,7 +38,7 @@ return [
     'google' => [
         'client_id' => env('GOOGLE_CLIENT_ID'),
         'client_secret' => env('GOOGLE_CLIENT_SECRET'),
-        'redirect' => config('app.url') . '/auth/google/callback',
+        'redirect' => config('app.url') . '/auth-google-callback',
     ],
 
 ];

--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -145,7 +145,7 @@
             </div>
 
             <div class="mt-3">
-                <a href="/auth/google/redirect" class="btn btn-outline-light w-100 d-flex align-items-center justify-content-center gap-2" style="background-color: #fff; color: #000; border-radius: 10px;">
+                <a href="/auth-google-redirect" class="btn btn-outline-light w-100 d-flex align-items-center justify-content-center gap-2" style="background-color: #fff; color: #000; border-radius: 10px;">
                     <img src="https://www.svgrepo.com/show/475656/google-color.svg" alt="Google" width="20">
                     <span>Masuk dengan Google</span>
                 </a>


### PR DESCRIPTION
This pull request updates the Google OAuth integration to use new redirect URLs, ensuring consistency between backend configuration and frontend links.

**Google OAuth integration:**

* Changed the Google OAuth redirect URI in `config/services.php` to `/auth-google-callback` for consistency and to match updated route naming conventions.
* Updated the Google login button link in `resources/views/auth/login.blade.php` to use `/auth-google-redirect`, aligning the frontend link with the new backend route.