### PR TITLE
Add MetricsController and health check routes for application monitoring

### DIFF
--- a/app/Http/Controllers/MetricsController.php
+++ b/app/Http/Controllers/MetricsController.php
@@ -1,0 +1,106 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Prometheus\CollectorRegistry;
+use Prometheus\RenderTextFormat;
+use Prometheus\Storage\Redis;
+use Illuminate\Routing\Controller;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Cache;
+
+class MetricsController extends Controller
+{
+    public function metrics()
+    {
+        // Ambil REDIS_URL dari .env
+        $redisUrl = env('REDIS_URL', 'redis://127.0.0.1:6379');
+
+        // Parse URL redis://user:pass@host:port
+        $parts = parse_url($redisUrl);
+
+        $host = $parts['host'] ?? '127.0.0.1';
+        $port = $parts['port'] ?? 6379;
+        $password = $parts['pass'] ?? null;
+
+        // Konfigurasi Redis adapter Prometheus
+        $adapter = new Redis([
+            'host' => $host,
+            'port' => $port,
+            'password' => $password,
+        ]);
+
+        $registry = new CollectorRegistry($adapter);
+
+        // Metric: HTTP request counter
+        $counter = $registry->getOrRegisterCounter(
+            'app',
+            'http_requests_total',
+            'Total number of HTTP requests',
+            ['method', 'route']
+        );
+
+        $counter->incBy(1, [request()->method(), request()->path()]);
+
+        // Render output Prometheus
+        $renderer = new RenderTextFormat();
+        return response($renderer->render($registry->getMetricFamilySamples()))
+            ->header('Content-Type', RenderTextFormat::MIME_TYPE);
+    }
+
+    /**
+     * Health check endpoint
+     */
+    public function health()
+    {
+        $status = [
+            'status' => 'healthy',
+            'timestamp' => now()->toIso8601String(),
+            'checks' => []
+        ];
+
+        // Database check
+        try {
+            DB::connection()->getPdo();
+            $status['checks']['database'] = 'ok';
+        } catch (\Exception $e) {
+            $status['checks']['database'] = 'failed';
+            $status['status'] = 'unhealthy';
+        }
+
+        // Cache check
+        try {
+            Cache::put('health_check', true, 10);
+            $cacheWorks = Cache::get('health_check');
+            $status['checks']['cache'] = $cacheWorks ? 'ok' : 'failed';
+        } catch (\Exception $e) {
+            $status['checks']['cache'] = 'failed';
+        }
+
+        $httpStatus = $status['status'] === 'healthy' ? 200 : 503;
+
+        return response()->json($status, $httpStatus);
+    }
+
+    /**
+     * Readiness probe - check if app is ready to receive traffic
+     */
+    public function ready()
+    {
+        // Check critical dependencies
+        try {
+            DB::connection()->getPdo();
+            return response()->json(['status' => 'ready'], 200);
+        } catch (\Exception $e) {
+            return response()->json(['status' => 'not ready'], 503);
+        }
+    }
+
+    /**
+     * Liveness probe - check if app is running
+     */
+    public function alive()
+    {
+        return response()->json(['status' => 'alive'], 200);
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,8 @@
         "laravel/tinker": "^2.10.1",
         "league/flysystem-aws-s3-v3": "3.0",
         "livewire/livewire": "^3.6",
-        "predis/predis": "^3.2"
+        "predis/predis": "^3.2",
+        "promphp/prometheus_client_php": "^2.14"
     },
     "require-dev": {
         "fakerphp/faker": "^1.23",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "bcdb61b6a7ded97f4f62e98221af7f45",
+    "content-hash": "f3d3e5c2cb7d63061bac98a320fefa07",
     "packages": [
         {
             "name": "aws/aws-crt-php",
@@ -3439,6 +3439,74 @@
                 }
             ],
             "time": "2025-08-06T06:41:24+00:00"
+        },
+        {
+            "name": "promphp/prometheus_client_php",
+            "version": "v2.14.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PromPHP/prometheus_client_php.git",
+                "reference": "a283aea8269287dc35313a0055480d950c59ac1f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PromPHP/prometheus_client_php/zipball/a283aea8269287dc35313a0055480d950c59ac1f",
+                "reference": "a283aea8269287dc35313a0055480d950c59ac1f",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "php": "^7.4|^8.0"
+            },
+            "replace": {
+                "endclothing/prometheus_client_php": "*",
+                "jimdo/prometheus_client_php": "*",
+                "lkaemmerling/prometheus_client_php": "*"
+            },
+            "require-dev": {
+                "guzzlehttp/guzzle": "^6.3|^7.0",
+                "phpstan/extension-installer": "^1.0",
+                "phpstan/phpstan": "^1.5.4",
+                "phpstan/phpstan-phpunit": "^1.1.0",
+                "phpstan/phpstan-strict-rules": "^1.1.0",
+                "phpunit/phpunit": "^9.4",
+                "squizlabs/php_codesniffer": "^3.6",
+                "symfony/polyfill-apcu": "^1.6"
+            },
+            "suggest": {
+                "ext-apc": "Required if using APCu.",
+                "ext-pdo": "Required if using PDO.",
+                "ext-redis": "Required if using Redis.",
+                "promphp/prometheus_push_gateway_php": "An easy client for using Prometheus PushGateway.",
+                "symfony/polyfill-apcu": "Required if you use APCu on PHP8.0+"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Prometheus\\": "src/Prometheus/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache-2.0"
+            ],
+            "authors": [
+                {
+                    "name": "Lukas Kämmerling",
+                    "email": "kontakt@lukas-kaemmerling.de"
+                }
+            ],
+            "description": "Prometheus instrumentation library for PHP applications.",
+            "support": {
+                "issues": "https://github.com/PromPHP/prometheus_client_php/issues",
+                "source": "https://github.com/PromPHP/prometheus_client_php/tree/v2.14.1"
+            },
+            "time": "2025-04-14T07:59:43+00:00"
         },
         {
             "name": "psr/clock",

--- a/routes/web.php
+++ b/routes/web.php
@@ -2,12 +2,19 @@
 
 use App\Http\Controllers\AuthController;
 use App\Http\Controllers\ProductController;
+use App\Http\Controllers\MetricsController;
 use Illuminate\Support\Facades\Route;
 
 // Public Routes
 Route::get('/', function () {
     return view('welcome');
 });
+
+// Monitoring & Health Check Routes
+Route::get('/metrics', [MetricsController::class, 'metrics'])->name('metrics');
+Route::get('/health', [MetricsController::class, 'health'])->name('health');
+Route::get('/ready', [MetricsController::class, 'ready'])->name('ready');
+Route::get('/alive', [MetricsController::class, 'alive'])->name('alive');
 
 // Authentication Routes
 


### PR DESCRIPTION
This pull request introduces monitoring and health check endpoints to the application, allowing for improved observability and readiness/liveness checks. The main changes include the addition of a new `MetricsController` to handle Prometheus metrics and health probes, updates to the routes to expose these endpoints, and the inclusion of a new dependency for Prometheus client support.

**Monitoring and Metrics Integration:**

* Added `MetricsController` with a `/metrics` endpoint that exposes Prometheus metrics, including an HTTP request counter, using the `promphp/prometheus_client_php` library and Redis storage.
* Updated `composer.json` to include the `promphp/prometheus_client_php` dependency for Prometheus metrics support.

**Health and Readiness Endpoints:**

* Implemented `/health`, `/ready`, and `/alive` endpoints in `MetricsController` for health, readiness, and liveness probes, checking database and cache connectivity and reporting app status.
* Registered new monitoring and health check routes in `routes/web.php` to expose these endpoints.