### PR TITLE
Refactor MetricsController: streamline Redis configuration and remove…

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -40,7 +40,6 @@ Route::middleware(['auth', 'check_role:admin'])->group(function () {
 });
 
 // Product Routes
-
 // Route::get('/products', [ProductController::class, 'index'])->name('dashboard-index');
 // Route::get('/create-product', [ProductController::class, 'create'])->name('products.create');
 // Route::post('/create-product', [ProductController::class, 'store'])->name('products.store');


### PR DESCRIPTION
This pull request refactors the way Redis connection parameters are handled in the `MetricsController`, switching from parsing a single `REDIS_URL` to using separate environment variables for host, port, and password. This change improves clarity and flexibility in configuring Redis connections. Additionally, some minor code clean-up was performed in the routes file.

Redis connection configuration:

* Refactored Redis setup in `MetricsController.php` to use `REDIS_HOST`, `REDIS_PORT`, and `REDIS_PASSWORD` environment variables directly, instead of parsing `REDIS_URL`. This makes the configuration more explicit and easier to manage.

Code clean-up:

* Removed unnecessary comments and improved code readability in the `metrics` method of `MetricsController.php`.
* Minor formatting clean-up in `routes/web.php` by removing an extra blank line.… unnecessary comments; clean up web routes by removing commented-out product routes.