### PR TITLE
Update composer.json and Makefile: correct command in dev script and …

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -48,7 +48,7 @@
         ],
         "dev": [
             "Composer\\Config::disableProcessTimeout",
-            "npx concurrently -c \"#93c5fd,#c4b5fd,#fb7185,#fdba74\" \"php artisan serve\" \"php artisan queue:listen --tries=1\" \"php artisan pail --timeout=0\" \"npm run dev\" --names=server,queue,logs,vite --kill-others"
+            "npx concurrently -c \"#93c5fd,#c4b5fd,#fb7185,#fdba74\" \"php artisan serve\" \"php artisan queue:listen --tries=1\" \"php artisan pail --timeout=0\" \"npm run dev\" --names=server,queue,logs,viters "
         ],
         "test": [
             "@php artisan config:clear --ansi",

--- a/makefile
+++ b/makefile
@@ -7,7 +7,7 @@ docker-run-prod:
 
 
 run-php:
-	php artisan serve
+	composer run dev
 
 run-vite:
 	npm run dev


### PR DESCRIPTION
This pull request updates the local development workflow by changing how the PHP server is started and adjusting the concurrent command configuration. The most notable changes are in the `composer.json` and `makefile`, affecting how development services are run together.

**Development workflow updates:**

* The `makefile` now uses `composer run dev` instead of directly running `php artisan serve`, which means all development services (PHP server, queue listener, logs, Vite) are started together using the configuration in `composer.json`.
* In `composer.json`, the concurrent command for the `dev` script has been updated: the Vite process is now labeled as `viters` instead of `vite`, and an extra space was added at the end of the names list. This affects how process names are displayed when running development services.…adjust run-php target to use composer